### PR TITLE
added text_sectors script

### DIFF
--- a/industrial_taxonomy/getters/text_sectors.py
+++ b/industrial_taxonomy/getters/text_sectors.py
@@ -15,16 +15,24 @@ glass_id = str
 def text_sectors(
     run: Optional[Run] = None,
 ) -> Dict[clustering_param, List[Tuple[sector_id, glass_id]]]:
-    """Gets text sector assignments from the topic modelling"""
+    """Gets text sector assignments from the topic modelling
 
+    Args:
+        run: what ClusterGlass flow run to use.
+            Defaults to the latest production run
+
+    Returns:
+        A lookup between cluster assignment parameters (how many
+        companies do we tell topsbm to assign to each cluster based on
+        their representativeness) and the actual cluster assignments
+        (a tuple with sector id and company id)
+
+    """
     run = run or get_run("ClusterGlass")
-
     return run.data.clusters
 
 
 def topsbm_models(run: Optional[Run] = None) -> Dict[sector_id, sbmtm]:
     """Gets topic models trained on each sector"""
-
     run = run or get_run("ClusterGlass")
-
     return run.data.models

--- a/industrial_taxonomy/getters/text_sectors.py
+++ b/industrial_taxonomy/getters/text_sectors.py
@@ -1,0 +1,30 @@
+"""Data getters for topsbm outputs"""
+
+from metaflow import Run
+from typing import Dict, List, Optional, Tuple
+
+from industrial_taxonomy.utils.metaflow import get_run
+from industrial_taxonomy.pipeline.glass_clusters.sbmtm import sbmtm
+
+
+clustering_param = str
+sector_id = str
+glass_id = str
+
+
+def text_sectors(
+    run: Optional[Run] = None,
+) -> Dict[clustering_param, List[Tuple[sector_id, glass_id]]]:
+    """Gets text sector assignments from the topic modelling"""
+
+    run = run or get_run("ClusterGlass")
+
+    return run.data.clusters
+
+
+def topsbm_models(run: Optional[Run] = None) -> Dict[sector_id, sbmtm]:
+    """Gets topic models trained on each sector"""
+
+    run = run or get_run("ClusterGlass")
+
+    return run.data.models


### PR DESCRIPTION
I created a `text_sectors` script with getters for the outputs of the text clustering (i.e. `ClusterGlass` flow). 

For now this only includes functions to get `text_sectors` and `topsbm_models` but going forward it could also include getters for reassigned text sectors etc.

---

Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have run `flake8` and addressed any linter erors
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have rebased onto `dev` (or merged any new changes from `dev`)
- [x] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained the feature in this PR or (better) in `output/reports/`
- [x] I have requested a code review
