### PR TITLE
Pin metaflow-extensions to SHA

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ typer
 sh
 xlrd
 openpyxl
-metaflow_extensions@git+https://github.com/nestauk/metaflow_extensions@25_fix_project_env
+metaflow_extensions@git+https://github.com/nestauk/metaflow_extensions@5035596
 pyyaml


### PR DESCRIPTION
Closes #37 


Without this PR anyone who tries to rebuild their environment will end up with a different `metaflow_extensions` that won't work anymore.