### PR TITLE
22 sector names

### DIFF
--- a/industrial_taxonomy/getters/text_sectors.py
+++ b/industrial_taxonomy/getters/text_sectors.py
@@ -32,6 +32,7 @@ def text_sectors(
     run = run or get_run("ClusterGlass")
     return run.data.clusters
 
+
 def text_sector_names_reassigned(
     run: Optional[Run] = None,
 ) -> Dict[clustering_param, Dict[sector_id, str]]:
@@ -117,7 +118,7 @@ def knn_assigned_text_sectors(
     if clustered:
         return run.data.knn_assigned_text_sectors
     else:
-        return run.data.knn_assigned_text_sectors_rest 
+        return run.data.knn_assigned_text_sectors_rest
 
 
 def knn_sims(
@@ -129,7 +130,7 @@ def knn_sims(
     if clustered:
         return run.data.knn_sims
     else:
-        return run.data.knn_sims_rest 
+        return run.data.knn_sims_rest
 
 
 def knn_text_sector_agg(

--- a/industrial_taxonomy/getters/text_sectors.py
+++ b/industrial_taxonomy/getters/text_sectors.py
@@ -32,6 +32,13 @@ def text_sectors(
     run = run or get_run("ClusterGlass")
     return run.data.clusters
 
+def text_sector_names_reassigned(
+    run: Optional[Run] = None,
+) -> Dict[clustering_param, Dict[sector_id, str]]:
+    """Gets text sector names."""
+    run = run or get_run("TextSectorName")
+    return run.data.sector_names
+
 
 def topsbm_models(run: Optional[Run] = None) -> Dict[sector_id, sbmtm]:
     """Gets topic models trained on each sector"""

--- a/industrial_taxonomy/pipeline/cluster_names/flow.py
+++ b/industrial_taxonomy/pipeline/cluster_names/flow.py
@@ -1,23 +1,31 @@
 import logging
-import numpy as np
-
 from metaflow import (
     conda,
     current,
     FlowSpec,
     project,
     step,
-    batch,
     Parameter,
 )
-
-logger = logging.getLogger(__name__)
 
 from industrial_taxonomy.getters.glass_house import (
     description_embeddings,
     embedded_org_descriptions,
     embedded_org_ids,
+    encoder_name,
 )
+
+from utils import (
+    split_dict,
+    sector_org_ids_lookup,
+    get_clusters_embeddings,
+    tfidf_vectors,
+    top_tfidf_terms,
+    central_ngrams,
+)
+
+
+logger = logging.getLogger(__name__)
 
 
 @project(name="industrial_taxonomy")
@@ -30,12 +38,131 @@ class TextSectorName(FlowSpec):
         default=lambda _: not current.is_production,
     )
 
+    @conda(
+        libraries={
+            "sentence-transformers": "2.2.0",
+        },
+    )
     @step
     def start(self):
-        pass
+        """Instantiates the sentence transformer used to embed Glass + CH
+        descriptions."""
+        from sentence_transformers import SentenceTransformer
+
+        self.encoder = SentenceTransformer(encoder_name())
+        self.next(self.load_text_sectors)
+
+    @conda(
+        libraries={
+            "graph-tool": "2.44",
+        },
+    )
+    @step
+    def load_text_sectors(self):
+        """Loads text sectors and truncates if in test mode."""
+        from industrial_taxonomy.getters.text_sectors import (
+            assigned_text_sector,
+            org_ids_reassigned,
+        )
+
+        text_sectors = assigned_text_sector()
+        org_ids = org_ids_reassigned()
+        min_len = min([len(c) for c in text_sectors.values()])
+        test_params = [k for k, v in text_sectors.items() if len(v) == min_len]
+
+        if self.test_mode and not current.is_production:
+            params = test_params
+        else:
+            params = text_sectors.keys()
+
+        self.params, text_sectors = split_dict(text_sectors, params)
+        _, org_ids = split_dict(org_ids, params)
+
+        self.text_sectors = []
+        for t, o in zip(text_sectors, org_ids):
+            self.text_sectors.append(list(zip(t, o)))
+
+        self.next(self.name_text_sectors, foreach="text_sectors")
+
+    @conda(
+        libraries={
+            "scikit-learn": "1.0.2",
+            "sentence-transformers": "2.2.0",
+        }
+    )
+    @step
+    def name_text_sectors(self):
+        """Generates names for the text sectors."""
+
+        from sklearn.feature_extraction.text import TfidfVectorizer
+        from sklearn.metrics import pairwise_distances
+
+        org_ids = embedded_org_ids()
+        embeddings = description_embeddings()
+        descriptions = embedded_org_descriptions()
+
+        sector_org_ids_index = sector_org_ids_lookup(self.input)
+
+        self.sector_names = {}
+
+        for label, sector_org_ids in sector_org_ids_index.items():
+            if len(sector_org_ids) <= 1:
+                self.sector_names[label] = None
+                continue
+
+            sector_clusters = [(label, org_id) for org_id in sector_org_ids]
+            sector_embeddings, sector_locs = get_clusters_embeddings(
+                sector_clusters,
+                org_ids,
+                embeddings,
+            )
+            sector_descriptions = [descriptions[i] for i in sector_locs]
+
+            if len(sector_descriptions) > 2:
+                min_df = 2
+            else:
+                min_df = 1
+
+            try:
+                sector_tfidf_vecs, tfidf_vectorizer = tfidf_vectors(
+                    sector_descriptions,
+                    TfidfVectorizer,
+                    min_df=min_df,
+                )
+            # some text sectors contain too few terms to calculate tf-idf
+            except ValueError:
+                self.sector_names[label] = None
+                continue
+
+            sector_top_ngrams = top_tfidf_terms(
+                sector_tfidf_vecs,
+                tfidf_vectorizer,
+                topn=20,
+            )
+
+            best_ngrams = central_ngrams(
+                sector_top_ngrams,
+                self.encoder,
+                sector_embeddings,
+                pairwise_distances,
+                topn=3,
+            )
+            self.sector_names[label] = ", ".join(best_ngrams)
+
+        self.next(self.join)
+
+    @step
+    def join(self, inputs):
+        """Joins names back into dict with clustering params."""
+        sector_names = [input.sector_names for input in inputs]
+        self.merge_artifacts(inputs, exclude=["sector_names"])
+        self.sector_names = dict([(p, s) for p, s in zip(self.params, sector_names)])
+
+        self.next(self.end)
 
     @step
     def end(self):
+        """No-op"""
         pass
 
 

--- a/industrial_taxonomy/pipeline/cluster_names/flow.py
+++ b/industrial_taxonomy/pipeline/cluster_names/flow.py
@@ -1,0 +1,43 @@
+import logging
+import numpy as np
+
+from metaflow import (
+    conda,
+    current,
+    FlowSpec,
+    project,
+    step,
+    batch,
+    Parameter,
+)
+
+logger = logging.getLogger(__name__)
+
+from industrial_taxonomy.getters.glass_house import (
+    description_embeddings,
+    embedded_org_descriptions,
+    embedded_org_ids,
+)
+
+
+@project(name="industrial_taxonomy")
+class TextSectorName(FlowSpec):
+
+    test_mode = Parameter(
+        "test-mode",
+        help="Whether to run in test mode (on a small subset of data)",
+        type=bool,
+        default=lambda _: not current.is_production,
+    )
+
+    @step
+    def start(self):
+        pass
+
+    @step
+    def end(self):
+        pass
+
+
+if __name__ == "__main__":
+    TextSectorName()

--- a/industrial_taxonomy/pipeline/cluster_names/utils.py
+++ b/industrial_taxonomy/pipeline/cluster_names/utils.py
@@ -9,6 +9,25 @@ def split_dict(d, params):
     return list(d.keys()), list(d.values())
 
 
+def get_locs(ids, vector_index):
+    """Gets the locations of some elements as they appear in an index."""
+    id_to_loc = dict(zip(vector_index, range(len(vector_index))))
+    locs = np.array(itemgetter(*ids)(id_to_loc))
+    return locs
+
+
+def sic4_lookups(text_sector_embedding_lookup):
+    """Generates a lookup between SIC4 codes, text sectors and Glass
+    organisation IDs."""
+    sic4_embedding_lookup = defaultdict(list)
+    sic4_text_sector_lookup = defaultdict(list)
+    for label, org_ids in text_sector_embedding_lookup.items():
+        sic4_embedding_lookup[label[:4]].extend(org_ids)
+        sic4_text_sector_lookup[label[:4]].append(label)
+        
+    return sic4_embedding_lookup, sic4_text_sector_lookup
+
+
 def sector_org_ids_lookup(sectors):
     """Creates a lookup between text sector labels and the Glass organisation
     IDs for the companies in that text sector."""

--- a/industrial_taxonomy/pipeline/cluster_names/utils.py
+++ b/industrial_taxonomy/pipeline/cluster_names/utils.py
@@ -1,0 +1,85 @@
+from collections import defaultdict
+import numpy as np
+from operator import itemgetter
+
+
+def split_dict(d, params):
+    """Splits dict into key and value lists to pass through `foreach` step."""
+    d = {k: v for k, v in d.items() if k in params}
+    return list(d.keys()), list(d.values())
+
+
+def sector_org_ids_lookup(sectors):
+    """Creates a lookup between text sector labels and the Glass organisation
+    IDs for the companies in that text sector."""
+    lookup = defaultdict(list)
+    for label, org_id in sectors:
+        lookup[label].append(org_id)
+    return lookup
+
+
+def get_clusters_embeddings(
+    clusters,
+    org_ids,
+    embeddings,
+):
+    """Returns the embeddings for a set of clusters.
+
+    Args:
+        clusters: List of cluster ID + org ID pairs.
+        org_ids: List of Glass org IDs corresponding to embedding rows.
+        embeddings: 2-D array of Glass org embeddings.
+
+    Returns:
+        Embeddings for the organisations in clusters, in the order that
+            they were passed.
+    """
+    glass_org_ids_clusters = [c[1] for c in clusters]
+    glass_org_id_to_loc = dict(zip(org_ids, range(len(org_ids))))
+    embedding_locs = np.array(itemgetter(*glass_org_ids_clusters)(glass_org_id_to_loc))
+    return embeddings[embedding_locs], embedding_locs
+
+
+def tfidf_vectors(texts, vectorizer, min_df=3, ngram_range=(2, 3)):
+    """Generates tf-idf vectors from a set of documents with some fixed
+    parameters."""
+    tfidf_vectorizer = vectorizer(
+        token_pattern=r"[A-Za-z]+",
+        analyzer="word",
+        ngram_range=ngram_range,
+        stop_words="english",
+        min_df=min_df,
+    )
+    return tfidf_vectorizer.fit_transform(texts), tfidf_vectorizer
+
+
+def top_tfidf_terms(tfidf_vectors, tfidf_vectorizer, topn=20):
+    """Sums the tf-idf values for each term across documents and sorts them by
+    score. Returns the `topn` with the highest tf-idf values."""
+    summed_tfidf = tfidf_vectors.sum(axis=0)
+
+    summed_tfidf_list = summed_tfidf.tolist()[0]
+    ngram_list = tfidf_vectorizer.get_feature_names()
+    ngram_scores = list(zip(summed_tfidf_list, ngram_list))
+    sorted_ngram_scores = sorted(
+        ngram_scores,
+        key=lambda tup: tup[0],
+        reverse=True,
+    )
+
+    return [ngram[1] for ngram in sorted_ngram_scores[:topn]]
+
+
+def central_ngrams(terms, encoder, sector_embeddings, dist_func, topn=3):
+    """Returns the `topn` terms that have the highest average pairwise cosine
+    similarity with the documents they were generated from."""
+    ngram_embeddings = encoder.encode(terms)
+
+    mean_sims = dist_func(
+        ngram_embeddings,
+        sector_embeddings,
+        metric="cosine",
+    ).mean(axis=1)
+    top_sim_locs = np.argsort(mean_sims)[:topn]
+
+    return [terms[i] for i in top_sim_locs]


### PR DESCRIPTION
Uses tf-idf and embedding cosine similarity to create names for text sectors (after reassignment).

closes #22 

---

Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have run `flake8` and addressed any linter erors
- [x] I have checked the code runs
- [ ] I have tested the code
- [ ] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have rebased onto `dev` (or merged any new changes from `dev`)
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained the feature in this PR or (better) in `output/reports/`
- [x] I have requested a code review
